### PR TITLE
fixed: Symfony Tree Builder deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^7.1.3",
-    "symfony/framework-bundle": "^4.0"
+    "symfony/framework-bundle": "^4.2"
   },
   "autoload": {
     "psr-4": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,9 +14,9 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('apixception');
         $treeBuilder
-            ->root('apixception')
+            ->getRootNode()
             ->arrayPrototype()
                 ->addDefaultsIfNotSet()
                 ->children()


### PR DESCRIPTION
Symfony Tree Builder deprecation fixed: "Symfony 4.2 deprecation: A tree builder without a root node is deprecated"